### PR TITLE
add a couple of getter methods

### DIFF
--- a/fontain/src/main/java/com/scopely/fontain/impls/FontFamilyImpl.java
+++ b/fontain/src/main/java/com/scopely/fontain/impls/FontFamilyImpl.java
@@ -73,4 +73,9 @@ public class FontFamilyImpl implements FontFamily {
 
         return (int) (1500 - Math.sqrt(weightDiff*weightDiff + widthDiff*widthDiff + slopeDiff*slopeDiff));
     }
+
+    @Override
+    public String getName() {
+        return name;
+    }
 }

--- a/fontain/src/main/java/com/scopely/fontain/impls/FontManagerImpl.java
+++ b/fontain/src/main/java/com/scopely/fontain/impls/FontManagerImpl.java
@@ -39,6 +39,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -153,6 +155,11 @@ public class FontManagerImpl implements FontManager {
             family = getDefaultFontFamily();
         }
         return family;
+    }
+
+    @Override
+    public Collection<FontFamily> getAllFontFamilies() {
+        return Collections.unmodifiableCollection(fontFamilyMap.values());
     }
 
     @Override

--- a/fontain/src/main/java/com/scopely/fontain/interfaces/FontFamily.java
+++ b/fontain/src/main/java/com/scopely/fontain/interfaces/FontFamily.java
@@ -30,4 +30,5 @@ public interface FontFamily {
     public Font getFont(int weight, int width, boolean italic);
     public Font getFont(Weight weight, Width width, Slope slope);
     public List<? extends Font> getFonts();
+    public String getName();
 }

--- a/fontain/src/main/java/com/scopely/fontain/interfaces/FontManager.java
+++ b/fontain/src/main/java/com/scopely/fontain/interfaces/FontManager.java
@@ -25,6 +25,8 @@ import com.android.internal.util.Predicate;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 /**
  * A FontManager manages all the FontFamilies and associated Fonts available.
  * It provides a default FontFamily and provides methods for accessing any other FontFamily by name.
@@ -35,6 +37,8 @@ public interface FontManager {
     FontFamily getDefaultFontFamily();
 
     FontFamily getFontFamily(String fontFamilyName);
+
+    Collection<FontFamily> getAllFontFamilies();
 
     Font getFont(Typeface typeface);
 


### PR DESCRIPTION
This adds two trivial methods, `FontManager.getAllFontFamilies()`, and `FontFamily.getName()` (and their respective implementations), which, together, enable callers to list the fonts in their app.
